### PR TITLE
Add tables to Redis to keep TX error monitor configuration and ports state

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -226,6 +226,8 @@ namespace swss {
 #define CFG_NAT_BINDINGS_TABLE_NAME                 "NAT_BINDINGS"
 #define CFG_NAT_GLOBAL_TABLE_NAME                   "NAT_GLOBAL"
 
+#define CFG_TX_ERROR_TABLE_NAME                     "TX_ERROR_CFG"
+
 /***** STATE DATABASE *****/
 
 #define STATE_SWITCH_CAPABILITY_TABLE_NAME          "SWITCH_CAPABILITY_TABLE"
@@ -246,6 +248,7 @@ namespace swss {
 #define STATE_BGP_TABLE_NAME                        "BGP_STATE_TABLE"
 #define STATE_DEBUG_COUNTER_CAPABILITIES_NAME       "DEBUG_COUNTER_CAPABILITIES"
 #define STATE_NAT_RESTORE_TABLE_NAME                "NAT_RESTORE_TABLE"
+#define STATE_TX_ERROR_TABLE_NAME                   "TX_ERROR_STATE_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
Related to [https://github.com/DavidZagury/sonic-swss/pull/1](url)